### PR TITLE
PLTool: Default to PL editor if no file is given as an argument

### DIFF
--- a/SA1Tools/PLTool/PLEditor.cs
+++ b/SA1Tools/PLTool/PLEditor.cs
@@ -17,14 +17,14 @@ namespace PLTool
         bool isGamecube = false;
         public string currentFilename = "";
 
-        public PLEditor()
-        {
-            InitializeComponent();
-            if (Program.Arguments.Length > 0)
-                LoadPLFile(Program.Arguments[0]);
-            else
-                CreateDefaultPalettes();
-        }
+		public PLEditor(string filepath = "")
+		{
+			InitializeComponent();
+			if (filepath != "" && File.Exists(filepath))
+				LoadPLFile(filepath);
+			else
+				CreateDefaultPalettes();
+		}
 
         private void CreateBlankPalettes()
         {

--- a/SA1Tools/PLTool/Program.cs
+++ b/SA1Tools/PLTool/Program.cs
@@ -27,10 +27,12 @@ namespace PLTool
                         break;
                     case "PL":
                     default:
-                        primaryForm = new PLEditor();
+                        primaryForm = new PLEditor(args[0]);
                         break;
                 }
-            Application.Run(primaryForm);
+			else
+				primaryForm = new PLEditor();
+			Application.Run(primaryForm);
         }
 
         static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)


### PR DESCRIPTION
Just a little QOL change.
The original behaviour had the program stay open and idle if it wasn't given a file as a parameter (Application.Run was given a null Form).
