### PR TITLE
SADXObjectDefinitions: Use Roslyn to compile object definitions

### DIFF
--- a/SA1Tools/SADXObjectDefinitions/app.config
+++ b/SA1Tools/SADXObjectDefinitions/app.config
@@ -1,12 +1,16 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-<probing privatePath="lib"/>  
+<probing privatePath="lib" />  
       <dependentAssembly>
-        <assemblyIdentity name="SharpDX" publicKeyToken="b4dcf0f35e5521f1" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
+        <assemblyIdentity name="SharpDX" publicKeyToken="b4dcf0f35e5521f1" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" /></startup></configuration>

--- a/SALVL/ObjectDefinitions.cs
+++ b/SALVL/ObjectDefinitions.cs
@@ -141,36 +141,36 @@ namespace SAModel.SALVL
 
         }
 
-		// System, System.Core, System.Drawing, SharpDX, SharpDX.Mathematics, SharpDX.Direct3D9,
-		// SALVL, SAModel, SAModel.Direct3D, SA Tools, SAEditorCommon
-		private static readonly MetadataReference[] objectDefinitionReferences =
-		new[]
-		{
-			MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
-			MetadataReference.CreateFromFile(typeof(System.Drawing.Bitmap).Assembly.Location),
-			MetadataReference.CreateFromFile(typeof(SharpDX.Mathematics.Interop.RawBool).Assembly.Location),
-			MetadataReference.CreateFromFile(typeof(Vector3).Assembly.Location),
-			MetadataReference.CreateFromFile(typeof(Device).Assembly.Location),
-			MetadataReference.CreateFromFile(typeof(LandTable).Assembly.Location),
-			MetadataReference.CreateFromFile(typeof(EditorCamera).Assembly.Location),
-			MetadataReference.CreateFromFile(typeof(SA1LevelAct).Assembly.Location),
-			MetadataReference.CreateFromFile(typeof(ObjectDefinition).Assembly.Location)
-		};
+        // System, System.Core, System.Drawing, SharpDX, SharpDX.Mathematics, SharpDX.Direct3D9,
+        // SALVL, SAModel, SAModel.Direct3D, SA Tools, SAEditorCommon
+        private static readonly MetadataReference[] objectDefinitionReferences =
+        new[]
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(System.Drawing.Bitmap).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(SharpDX.Mathematics.Interop.RawBool).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Vector3).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Device).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(LandTable).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(EditorCamera).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(SA1LevelAct).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(ObjectDefinition).Assembly.Location)
+        };
 
-		private static readonly CSharpCompilationOptions objectDefinitionOptions =
-			new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
-				.WithOverflowChecks(true)
-				.WithOptimizationLevel(OptimizationLevel.Release);
+        private static readonly CSharpCompilationOptions objectDefinitionOptions =
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithOverflowChecks(true)
+                .WithOptimizationLevel(OptimizationLevel.Release);
 
-		private static ObjectDefinition CompileObjectDefinition(ObjectData defgroup, out bool errorOccured, out string errorText)
+        private static ObjectDefinition CompileObjectDefinition(ObjectData defgroup, out bool errorOccured, out string errorText)
         {
             ObjectDefinition def;
             errorOccured = false;
             errorText = "";
             string codeType = defgroup.CodeType;
             string dllfile = Path.Combine("dllcache", codeType + ".dll");
-			string pdbfile = Path.Combine("dllcache", codeType + ".pdb");
-			DateTime modDate = DateTime.MinValue;
+            string pdbfile = Path.Combine("dllcache", codeType + ".pdb");
+            DateTime modDate = DateTime.MinValue;
             if (File.Exists(dllfile)) modDate = File.GetLastWriteTime(dllfile);
             string fp = defgroup.CodeFile.Replace('/', Path.DirectorySeparatorChar);
             if (modDate >= File.GetLastWriteTime(fp) && modDate > File.GetLastWriteTime(Application.ExecutablePath))
@@ -183,48 +183,48 @@ namespace SAModel.SALVL
             }
             else
             {
-				SyntaxTree[] st = new[] { SyntaxFactory.ParseSyntaxTree(File.ReadAllText(fp), CSharpParseOptions.Default, fp, Encoding.UTF8) };
+                SyntaxTree[] st = new[] { SyntaxFactory.ParseSyntaxTree(File.ReadAllText(fp), CSharpParseOptions.Default, fp, Encoding.UTF8) };
 
-				CSharpCompilation compilation =
-						CSharpCompilation.Create(codeType, st, objectDefinitionReferences, objectDefinitionOptions);
+                CSharpCompilation compilation =
+                        CSharpCompilation.Create(codeType, st, objectDefinitionReferences, objectDefinitionOptions);
 
-				try
-				{
-					EmitResult result = compilation.Emit(dllfile, pdbfile);
+                try
+                {
+                    EmitResult result = compilation.Emit(dllfile, pdbfile);
 
-					if (!result.Success)
-					{
-						errorOccured = true;
-						foreach (Diagnostic diagnostic in result.Diagnostics)
-						{
-							errorText += String.Format("\n\n{0}", diagnostic.ToString());
-						}
+                    if (!result.Success)
+                    {
+                        errorOccured = true;
+                        foreach (Diagnostic diagnostic in result.Diagnostics)
+                        {
+                            errorText += String.Format("\n\n{0}", diagnostic.ToString());
+                        }
 
-						File.Delete(dllfile);
-						File.Delete(pdbfile);
+                        File.Delete(dllfile);
+                        File.Delete(pdbfile);
 
-						def = new DefaultObjectDefinition();
-					}
-					else
-					{
-						def =
-							(ObjectDefinition)
-								Activator.CreateInstance(
-									Assembly.LoadFile(Path.Combine(Environment.CurrentDirectory, dllfile))
-										.GetType(codeType));
-					}
-				}
-				catch (Exception e)
-				{
-					errorOccured = true;
-					errorText = String.Format("\n\n{0}", e.ToString());
+                        def = new DefaultObjectDefinition();
+                    }
+                    else
+                    {
+                        def =
+                            (ObjectDefinition)
+                                Activator.CreateInstance(
+                                    Assembly.LoadFile(Path.Combine(Environment.CurrentDirectory, dllfile))
+                                        .GetType(codeType));
+                    }
+                }
+                catch (Exception e)
+                {
+                    errorOccured = true;
+                    errorText = String.Format("\n\n{0}", e.ToString());
 
-					File.Delete(dllfile);
-					File.Delete(pdbfile);
+                    File.Delete(dllfile);
+                    File.Delete(pdbfile);
 
-					def = new DefaultObjectDefinition();
-				}
-			}
+                    def = new DefaultObjectDefinition();
+                }
+            }
             return def;
         }
 

--- a/SALVL/ObjectDefinitions.cs
+++ b/SALVL/ObjectDefinitions.cs
@@ -5,11 +5,14 @@ using SAModel.SAEditorCommon.DataTypes;
 using SAModel.SAEditorCommon.SETEditing;
 using SplitTools;
 using System;
-using System.CodeDom.Compiler;
+using System.Text;
 using System.Reflection;
 using SAModel.Direct3D;
 using SharpDX;
 using SharpDX.Direct3D9;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Emit;
 
 namespace SAModel.SALVL
 {
@@ -138,14 +141,36 @@ namespace SAModel.SALVL
 
         }
 
-        private static ObjectDefinition CompileObjectDefinition(ObjectData defgroup, out bool errorOccured, out string errorText)
+		// System, System.Core, System.Drawing, SharpDX, SharpDX.Mathematics, SharpDX.Direct3D9,
+		// SALVL, SAModel, SAModel.Direct3D, SA Tools, SAEditorCommon
+		private static readonly MetadataReference[] objectDefinitionReferences =
+		new[]
+		{
+			MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+			MetadataReference.CreateFromFile(typeof(System.Drawing.Bitmap).Assembly.Location),
+			MetadataReference.CreateFromFile(typeof(SharpDX.Mathematics.Interop.RawBool).Assembly.Location),
+			MetadataReference.CreateFromFile(typeof(Vector3).Assembly.Location),
+			MetadataReference.CreateFromFile(typeof(Device).Assembly.Location),
+			MetadataReference.CreateFromFile(typeof(LandTable).Assembly.Location),
+			MetadataReference.CreateFromFile(typeof(EditorCamera).Assembly.Location),
+			MetadataReference.CreateFromFile(typeof(SA1LevelAct).Assembly.Location),
+			MetadataReference.CreateFromFile(typeof(ObjectDefinition).Assembly.Location)
+		};
+
+		private static readonly CSharpCompilationOptions objectDefinitionOptions =
+			new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+				.WithOverflowChecks(true)
+				.WithOptimizationLevel(OptimizationLevel.Release);
+
+		private static ObjectDefinition CompileObjectDefinition(ObjectData defgroup, out bool errorOccured, out string errorText)
         {
             ObjectDefinition def;
             errorOccured = false;
             errorText = "";
             string codeType = defgroup.CodeType;
             string dllfile = Path.Combine("dllcache", codeType + ".dll");
-            DateTime modDate = DateTime.MinValue;
+			string pdbfile = Path.Combine("dllcache", codeType + ".pdb");
+			DateTime modDate = DateTime.MinValue;
             if (File.Exists(dllfile)) modDate = File.GetLastWriteTime(dllfile);
             string fp = defgroup.CodeFile.Replace('/', Path.DirectorySeparatorChar);
             if (modDate >= File.GetLastWriteTime(fp) && modDate > File.GetLastWriteTime(Application.ExecutablePath))
@@ -158,60 +183,48 @@ namespace SAModel.SALVL
             }
             else
             {
-                string ext = Path.GetExtension(fp);
-                CodeDomProvider pr = null;
-                switch (ext.ToLowerInvariant())
-                {
-                    case ".cs":
-                        pr = new Microsoft.CSharp.CSharpCodeProvider();
-                        break;
-                    case ".vb":
-                        pr = new Microsoft.VisualBasic.VBCodeProvider();
-                        break;
-                }
-                if (pr != null)
-                {
-                    // System, System.Core, System.Drawing, SharpDX, SharpDX.Mathematics, SharpDX.Direct3D9,
-                    // SALVL, SAModel, SAModel.Direct3D, SA Tools, SAEditorCommon
-                    CompilerParameters para =
-                        new CompilerParameters(new string[]
-                        {
-                            "System.dll", "System.Core.dll", "System.Drawing.dll", Assembly.GetAssembly(typeof(SharpDX.Mathematics.Interop.RawBool)).Location,
-                            Assembly.GetAssembly(typeof(Vector3)).Location, Assembly.GetAssembly(typeof(Device)).Location,
-                            Assembly.GetExecutingAssembly().Location, Assembly.GetAssembly(typeof(LandTable)).Location,
-                            Assembly.GetAssembly(typeof(EditorCamera)).Location, Assembly.GetAssembly(typeof(SA1LevelAct)).Location,
-                            Assembly.GetAssembly(typeof(ObjectDefinition)).Location
-                        })
-                        {
-                            GenerateExecutable = false,
-                            GenerateInMemory = false,
-                            IncludeDebugInformation = true,
-                            OutputAssembly = Path.Combine(Environment.CurrentDirectory, dllfile)
-                        };
-                    CompilerResults res = pr.CompileAssemblyFromFile(para, fp);
-                    if (res.Errors.HasErrors)
-                    {
-                        string errors = null;
-                        foreach (CompilerError item in res.Errors)
-                            errors += String.Format("\n\n{0}, {1}: {2}", item.Line, item.Column, item.ErrorText);
+				SyntaxTree[] st = new[] { SyntaxFactory.ParseSyntaxTree(File.ReadAllText(fp), CSharpParseOptions.Default, fp, Encoding.UTF8) };
 
-                        errorText = errors;
-                        errorOccured = true;
+				CSharpCompilation compilation =
+						CSharpCompilation.Create(codeType, st, objectDefinitionReferences, objectDefinitionOptions);
 
-                        def = new DefaultObjectDefinition();
-                    }
-                    else
-                    {
-                        def = (ObjectDefinition)Activator.CreateInstance(res.CompiledAssembly.GetType(codeType));
-                    }
-                }
-                else
-                {
-                    def = new DefaultObjectDefinition();
-                    errorText = "Code DOM Provider was null";
-                    errorOccured = true;
-                }
-            }
+				try
+				{
+					EmitResult result = compilation.Emit(dllfile, pdbfile);
+
+					if (!result.Success)
+					{
+						errorOccured = true;
+						foreach (Diagnostic diagnostic in result.Diagnostics)
+						{
+							errorText += String.Format("\n\n{0}", diagnostic.ToString());
+						}
+
+						File.Delete(dllfile);
+						File.Delete(pdbfile);
+
+						def = new DefaultObjectDefinition();
+					}
+					else
+					{
+						def =
+							(ObjectDefinition)
+								Activator.CreateInstance(
+									Assembly.LoadFile(Path.Combine(Environment.CurrentDirectory, dllfile))
+										.GetType(codeType));
+					}
+				}
+				catch (Exception e)
+				{
+					errorOccured = true;
+					errorText = String.Format("\n\n{0}", e.ToString());
+
+					File.Delete(dllfile);
+					File.Delete(pdbfile);
+
+					def = new DefaultObjectDefinition();
+				}
+			}
             return def;
         }
 

--- a/SALVL/SALVL.csproj
+++ b/SALVL/SALVL.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.2\build\Microsoft.CodeAnalysis.Analyzers.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.2\build\Microsoft.CodeAnalysis.Analyzers.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -49,6 +50,12 @@
       <HintPath>..\packages\AssimpNet.4.1.0\lib\net40\AssimpNet.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Microsoft.CodeAnalysis, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.4.0.1\lib\netstandard2.0\Microsoft.CodeAnalysis.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.4.0.1\lib\netstandard2.0\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+    </Reference>
     <Reference Include="SharpDX, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
       <HintPath>..\packages\SharpDX.4.2.0\lib\net45\SharpDX.dll</HintPath>
       <Private>False</Private>
@@ -62,8 +69,33 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Collections.Immutable, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.5.0.0\lib\net461\System.Collections.Immutable.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reflection.Metadata, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.5.0.0\lib\net461\System.Reflection.Metadata.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.5.0.0\lib\net45\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Encoding.CodePages, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encoding.CodePages.4.5.1\lib\net461\System.Text.Encoding.CodePages.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="VrSharp, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -235,6 +267,10 @@
     <None Include="Resources\editinfo.png" />
     <None Include="Resources\save_advanced.png" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.2\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.2\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\AssimpNet.4.1.0\build\AssimpNet.targets" Condition="Exists('..\packages\AssimpNet.4.1.0\build\AssimpNet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
@@ -242,7 +278,10 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\AssimpNet.4.1.0\build\AssimpNet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\AssimpNet.4.1.0\build\AssimpNet.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.2\build\Microsoft.CodeAnalysis.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.2\build\Microsoft.CodeAnalysis.Analyzers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.2\build\Microsoft.CodeAnalysis.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.2\build\Microsoft.CodeAnalysis.Analyzers.targets'))" />
   </Target>
+  <Import Project="..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.2\build\Microsoft.CodeAnalysis.Analyzers.targets" Condition="Exists('..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.2\build\Microsoft.CodeAnalysis.Analyzers.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/SALVL/app.config
+++ b/SALVL/app.config
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 <configSections>
     <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-        <section name="SAModel.SALVL.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false"/>
+        <section name="SAModel.SALVL.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
     </sectionGroup>
 </configSections>
 <startup>
-  <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
+  <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
 </startup>
   <System.Windows.Forms.ApplicationConfigurationSection>
-     <add key="DpiAwareness" value="PerMonitorV2"/>
+     <add key="DpiAwareness" value="PerMonitorV2" />
      <!--
      <add key="Form.DisableSinglePassScalingOfDpiForms" value="true"/>
      <add key="ToolStrip.DisableHighDpiImprovements" value="true"/>
@@ -22,16 +22,20 @@
   <userSettings>
         <SAModel.SALVL.Properties.Settings>
               <setting name="Username" serializeAs="String">
-                    <value/>
+                    <value />
               </setting>
         </SAModel.SALVL.Properties.Settings>
     </userSettings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-	 <probing privatePath="lib"/>
+	 <probing privatePath="lib" />
       <dependentAssembly>
-        <assemblyIdentity name="SharpDX" publicKeyToken="b4dcf0f35e5521f1" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
+        <assemblyIdentity name="SharpDX" publicKeyToken="b4dcf0f35e5521f1" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/SALVL/packages.config
+++ b/SALVL/packages.config
@@ -1,7 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AssimpNet" version="4.1.0" targetFramework="net48" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="3.3.2" targetFramework="net48" developmentDependency="true" />
+  <package id="Microsoft.CodeAnalysis.Common" version="4.0.1" targetFramework="net48" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="4.0.1" targetFramework="net48" />
   <package id="SharpDX" version="4.2.0" targetFramework="net47" />
   <package id="SharpDX.Direct3D9" version="4.2.0" targetFramework="net47" />
   <package id="SharpDX.Mathematics" version="4.2.0" targetFramework="net47" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
+  <package id="System.Collections.Immutable" version="5.0.0" targetFramework="net48" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net48" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
+  <package id="System.Reflection.Metadata" version="5.0.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net48" />
+  <package id="System.Text.Encoding.CodePages" version="4.5.1" targetFramework="net48" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
I saw that .NET 5.0 no longer supported System.CodeDom.Compiler so I had a go at switching it to the Roslyn libraries.