### PR TITLE
SA2MessageEditor, SA2CutsceneTextEditor: Fixed wrong "Centered" optio…

### DIFF
--- a/SA2Tools/SA2CutsceneTextEditor/MainForm.cs
+++ b/SA2Tools/SA2CutsceneTextEditor/MainForm.cs
@@ -436,7 +436,7 @@ namespace SA2CutsceneTextEditor
 		{
 			Character = ByteConverter.ToInt32(file, address);
 			Text = file.GetCString((int)(ByteConverter.ToUInt32(file, address + 4) - imageBase), encoding);
-			if (Text.StartsWith("\a"))
+			if (!string.IsNullOrEmpty(Text) && Text[0] == '\a')
 				Text = Text.TrimStart('\a');
 			else
 				Centered = false;

--- a/SA2Tools/SA2MessageFileEditor/MainForm.cs
+++ b/SA2Tools/SA2MessageFileEditor/MainForm.cs
@@ -513,7 +513,7 @@ namespace SA2MessageFileEditor
 				if (next == -1)
 				{
 					msg.Text = text.Substring(c);
-					if (msg.Text.StartsWith("\a"))
+					if (!string.IsNullOrEmpty(msg.Text) && msg.Text[0] == '\a')
 						msg.Text = msg.Text.TrimStart('\a');
 					else
 						msg.Centered = false;
@@ -522,7 +522,7 @@ namespace SA2MessageFileEditor
 				if (next != c)
 				{
 					msg.Text = text.Substring(c, next - c);
-					if (msg.Text.StartsWith("\a"))
+					if (!string.IsNullOrEmpty(msg.Text) && msg.Text[0] == '\a')
 						msg.Text = msg.Text.TrimStart('\a');
 					else
 						msg.Centered = false;


### PR DESCRIPTION
In these editors, after loading file, no matter whether the specific line is actually centered or not, the centered option will always be checked. 