### PR TITLE
Add decoding and export of GRND blocks in mld files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,3 +229,11 @@ pip-log.txt
 /buildSATools.dll
 /buildSATools.deps.json
 /SA2Tools/SA2ObjectDefinitions/Chao/tree.cs
+/SOAMLDExtract_Tests/SOAMLDExtract_Tests.csproj
+/SOAMLDExtract_Tests/z_SOAMLDExtract_Tests.csproj
+/SOAMLDExtract_Tests/test_mlds/a099h.mld
+/SOAMLDExtract_Tests/GlobalUsings.cs
+/SOAMLDExtract_Tests/UnitTest1.cs
+/SOAMLDExtract_Tests/test_mlds/a099h_dec.mld
+/SOAMLDExtract_Tests/test_mlds/a099h
+/SA Tools.sln

--- a/.gitignore
+++ b/.gitignore
@@ -229,11 +229,3 @@ pip-log.txt
 /buildSATools.dll
 /buildSATools.deps.json
 /SA2Tools/SA2ObjectDefinitions/Chao/tree.cs
-/SOAMLDExtract_Tests/SOAMLDExtract_Tests.csproj
-/SOAMLDExtract_Tests/z_SOAMLDExtract_Tests.csproj
-/SOAMLDExtract_Tests/test_mlds/a099h.mld
-/SOAMLDExtract_Tests/GlobalUsings.cs
-/SOAMLDExtract_Tests/UnitTest1.cs
-/SOAMLDExtract_Tests/test_mlds/a099h_dec.mld
-/SOAMLDExtract_Tests/test_mlds/a099h
-/SA Tools.sln

--- a/Libraries/ArchiveLib/SkiesOfArcadia.cs
+++ b/Libraries/ArchiveLib/SkiesOfArcadia.cs
@@ -84,7 +84,6 @@ namespace ArchiveLib
 			public Vertex[] Vertices;
 			public List<NJS_MESHSET> Meshes;
 			public Vertex Center;
-			public Vertex Origin;
 			public short XCount;
 			public short ZCount;
 			public short XLen;
@@ -109,12 +108,11 @@ namespace ArchiveLib
 				int ptr_triangles = ByteConverter.ToInt32(file, addr) + addr;
 				int ptr_quadtree = ByteConverter.ToInt32(file, addr + 4) + addr + 4;
 				
-				Origin = new Vertex(ByteConverter.ToSingle(file, addr + 8), 0.0f, ByteConverter.ToSingle(file, addr + 0xc));
+				Center = new Vertex(ByteConverter.ToSingle(file, addr + 8), 0.0f, ByteConverter.ToSingle(file, addr + 0xc));
 				XCount = ByteConverter.ToInt16(file, addr + 0x10);   //Might be unsigned?
 				ZCount = ByteConverter.ToInt16(file, addr + 0x12);   //Might be unsigned?
 				XLen = ByteConverter.ToInt16(file, addr + 0x14);   //Might be unsigned?
 				ZLen = ByteConverter.ToInt16(file, addr + 0x16);   //Might be unsigned?
-				Center = new Vertex(Origin.X + XCount / 2 * XLen, 0.0f, Origin.Z + (ZCount / 2) * ZLen);
 				
 				short tri_count = ByteConverter.ToInt16(file, addr + 0x18);
 				short quad_count = ByteConverter.ToInt16(file, addr + 0x1a);

--- a/Libraries/ArchiveLib/SkiesOfArcadia.cs
+++ b/Libraries/ArchiveLib/SkiesOfArcadia.cs
@@ -282,7 +282,7 @@ namespace ArchiveLib
 				case "GOBJ":
 
 					Type = GroundType.GroundObject;
-					GOBJChunk = new GOBJ(File, 0);
+					//GOBJChunk = new GOBJ(File, 0);
 					break;
 				default:
 					Console.WriteLine("Unknown Ground Format Found: %s", magic);
@@ -706,7 +706,7 @@ namespace ArchiveLib
 							mfile.SaveToFile(Path.Combine(directory, ground.Name + ".grnd.sa2mdl"));
 							break;
 						case nmldGround.GroundType.GroundObject:
-							Entries.Add(new MLDArchiveEntry(ground.File, ground.Name + ".gobj"));
+							//Entries.Add(new MLDArchiveEntry(ground.File, ground.Name + ".gobj"));
 							//mfile.SaveToFile(Path.Combine(directory, ground.Name + ".gobj.sa2mdl"));
 							break;
 						case nmldGround.GroundType.Unknown:

--- a/Libraries/ArchiveLib/SkiesOfArcadia.cs
+++ b/Libraries/ArchiveLib/SkiesOfArcadia.cs
@@ -177,20 +177,6 @@ namespace ArchiveLib
 
 		public class GOBJ
 		{
-			// For Reference, the setup for a GOBJ is as follows:
-			// 0x00	- "GOBJ"
-			// 0x04	- Chunk Size (Includes first 16 bytes),
-			// 0x08	- Int; null[2]
-
-			// GOBJ "Header" begins at 0x10 in a GOBJ Chunk.
-			// 0x00	- NJS_OBJECT
-			// NJS_OBJECT should have a child.
-			// Said child node will have a ChunkAttach/NJS_MODEL_CNK, the child pointer is set but it also seems to always follow the first NJS_OBJECT.
-			// As stated above, all pointers are relative to the location of the pointer EXCEPT for the ChunkAttach Pointer for the child.
-			// It has a 1 which does not correspond to the ChunkAttach/NJS_MODEL_CNK's location.
-			// Its location will be immediately after the child NJS_OBJECT.
-			// It's also in a flipped order. The Center/Radius comes first, then the VertexChunk pointer, and the PolyChunk pointer at the end.
-
 			public NJS_OBJECT Object;
 			public BoundingSphere Bounds;
 			public NJS_OBJECT GroundObject;
@@ -276,11 +262,39 @@ namespace ArchiveLib
 			switch (magic)
 			{
 				case "GRND":
+					// For Reference, the setup for a GRND is as follows:
+					// 0x00	- "GRND"
+					// 0x04	- Chunk Size (Includes first 16 bytes).
+					// 0x08	- Int; null[2]
+
+					// GRND Header begins at 0x10 in a GRND Chunk.
+					// 0x00	- Pointer to Vertex Chunk
+					// 0x04	- Pointer to Poly Chunk
+					// 0x08	- Float; X Pos?
+					// 0x0C	- Float; Z Pos?
+					// 0x10	- Short; Flags?
+					// 0x12	- Short; Flags?
+					// 0x14	- Short; X Dimension?
+					// 0x16 - Short; Z Dimension?
+					// 0x18	- Short; Unknown, seems to always be 2.
+					// 0x1A	- Short; Poly Count
 					Type = GroundType.Ground;
 					GRNDObj = new GRND(File, 0);
 					break;
 				case "GOBJ":
+					// For Reference, the setup for a GOBJ is as follows:
+					// 0x00	- "GOBJ"
+					// 0x04	- Chunk Size (Includes first 16 bytes),
+					// 0x08	- Int; null[2]
 
+					// GOBJ "Header" begins at 0x10 in a GOBJ Chunk.
+					// 0x00	- NJS_OBJECT
+					// NJS_OBJECT should have a child.
+					// Said child node will have a ChunkAttach/NJS_MODEL_CNK, the child pointer is set but it also seems to always follow the first NJS_OBJECT.
+					// As stated above, all pointers are relative to the location of the pointer EXCEPT for the ChunkAttach Pointer for the child.
+					// It has a 1 which does not correspond to the ChunkAttach/NJS_MODEL_CNK's location.
+					// Its location will be immediately after the child NJS_OBJECT.
+					// It's also in a flipped order. The Center/Radius comes first, then the VertexChunk pointer, and the PolyChunk pointer at the end.
 					Type = GroundType.GroundObject;
 					//GOBJChunk = new GOBJ(File, 0);
 					break;

--- a/Libraries/ArchiveLib/SkiesOfArcadia.cs
+++ b/Libraries/ArchiveLib/SkiesOfArcadia.cs
@@ -258,7 +258,7 @@ namespace ArchiveLib
 			{
 				case "GRND":
 					Type = GroundType.Ground;
-					//GRNDChunk = new GRND(File, 0);
+					GRNDObj = new GRND(File, 0);
 					break;
 				case "GOBJ":
 
@@ -273,12 +273,11 @@ namespace ArchiveLib
 
 			// Currently non-function due to weird poly format.
 			// Can uncomment once conversion is fixed.
-			/*
 			if (Type == GroundType.Ground)
 			{
 				ConvertedObject = GRNDChunk.ToObject();
 			}
-
+			/*
 			if (Type == GroundType.GroundObject)
 			{
 				ConvertedObject = GOBJChunk.GroundObject;

--- a/Libraries/ArchiveLib/SkiesOfArcadia.cs
+++ b/Libraries/ArchiveLib/SkiesOfArcadia.cs
@@ -153,8 +153,10 @@ namespace ArchiveLib
 						int v1_ind = (int)ByteConverter.ToUInt16(file, tri_offset + j * 4);
 						int v2_ind = (int) ByteConverter.ToUInt16(file, tri_offset + j * 4 + 4);
 						int v3_ind = (int)ByteConverter.ToUInt16(file, tri_offset + j * 4 + 8);
+						bool reversed = ByteConverter.ToInt16(file, tri_offset + j * 4 + 0xa) < 0;
 
-						tris.Add(new Triangle((ushort)vert_list.Count, (ushort) (vert_list.Count + 1), (ushort) (vert_list.Count + 2)));
+						if (reversed) { tris.Add(new Triangle((ushort)(vert_list.Count + 2), (ushort) (vert_list.Count + 1), (ushort) vert_list.Count)); }
+						else { tris.Add(new Triangle((ushort)vert_list.Count, (ushort)(vert_list.Count + 1), (ushort)(vert_list.Count + 2))); }
 
 						vert_list.Add(new Vertex(file, vert_offset + v1_ind * 4));
 						vert_list.Add(new Vertex(file, vert_offset + v2_ind * 4));

--- a/Libraries/ArchiveLib/SkiesOfArcadia.cs
+++ b/Libraries/ArchiveLib/SkiesOfArcadia.cs
@@ -702,8 +702,8 @@ namespace ArchiveLib
 					switch (ground.Type)
 					{
 						case nmldGround.GroundType.Ground:
-							// Entries.Add(new MLDArchiveEntry(ground.File, ground.Name + ".grnd"));
-							mfile.SaveToFile(Path.Combine(directory, ground.Name + ".grnd.sa2mdl"));
+							Entries.Add(new MLDArchiveEntry(mfile.ToBytes(Path.Combine(directory, ground.Name + ".grnd.sa2mdl")), ground.Name + ".grnd.sa2mdl"));
+							// mfile.SaveToFile(Path.Combine(directory, ground.Name + ".grnd.sa2mdl"));
 							break;
 						case nmldGround.GroundType.GroundObject:
 							//Entries.Add(new MLDArchiveEntry(ground.File, ground.Name + ".gobj"));

--- a/Libraries/ArchiveLib/SkiesOfArcadia.cs
+++ b/Libraries/ArchiveLib/SkiesOfArcadia.cs
@@ -358,11 +358,15 @@ namespace ArchiveLib
 	public class nmldEntry
 	{
 		public int Index { get; set; } = 0;
+		public int TblID { get; set; } = 0;
+		public List<int> GroundLinks { get; set; } = new();
+		public List<int> ParamList2 { get; set; } = new();
+		public List<int> FunctionParameters { get; set; } = new();
 		public List<nmldObject> Objects { get; set; } = new();
 		public List<nmldMotion> Motions { get; set; } = new();
 		public List<nmldGround> Grounds { get; set; } = new();
 		public nmldTextureList Texlist { get; set; } = new();
-		public string Name { get; set; } = string.Empty;
+		public string Fxn { get; set; } = string.Empty;
 		public Vertex Position { get; set; } = new();
 		public Vertex Rotation { get; set; } = new();
 		public Vertex Scale { get; set; } = new();

--- a/Libraries/ArchiveLib/SkiesOfArcadia.cs
+++ b/Libraries/ArchiveLib/SkiesOfArcadia.cs
@@ -177,6 +177,20 @@ namespace ArchiveLib
 
 		public class GOBJ
 		{
+			// For Reference, the setup for a GOBJ is as follows:
+			// 0x00	- "GOBJ"
+			// 0x04	- Chunk Size (Includes first 16 bytes),
+			// 0x08	- Int; null[2]
+
+			// GOBJ "Header" begins at 0x10 in a GOBJ Chunk.
+			// 0x00	- NJS_OBJECT
+			// NJS_OBJECT should have a child.
+			// Said child node will have a ChunkAttach/NJS_MODEL_CNK, the child pointer is set but it also seems to always follow the first NJS_OBJECT.
+			// As stated above, all pointers are relative to the location of the pointer EXCEPT for the ChunkAttach Pointer for the child.
+			// It has a 1 which does not correspond to the ChunkAttach/NJS_MODEL_CNK's location.
+			// Its location will be immediately after the child NJS_OBJECT.
+			// It's also in a flipped order. The Center/Radius comes first, then the VertexChunk pointer, and the PolyChunk pointer at the end.
+
 			public NJS_OBJECT Object;
 			public BoundingSphere Bounds;
 			public NJS_OBJECT GroundObject;
@@ -262,39 +276,11 @@ namespace ArchiveLib
 			switch (magic)
 			{
 				case "GRND":
-					// For Reference, the setup for a GRND is as follows:
-					// 0x00	- "GRND"
-					// 0x04	- Chunk Size (Includes first 16 bytes).
-					// 0x08	- Int; null[2]
-
-					// GRND Header begins at 0x10 in a GRND Chunk.
-					// 0x00	- Pointer to Vertex Chunk
-					// 0x04	- Pointer to Poly Chunk
-					// 0x08	- Float; X Pos?
-					// 0x0C	- Float; Z Pos?
-					// 0x10	- Short; Flags?
-					// 0x12	- Short; Flags?
-					// 0x14	- Short; X Dimension?
-					// 0x16 - Short; Z Dimension?
-					// 0x18	- Short; Unknown, seems to always be 2.
-					// 0x1A	- Short; Poly Count
 					Type = GroundType.Ground;
 					GRNDObj = new GRND(File, 0);
 					break;
 				case "GOBJ":
-					// For Reference, the setup for a GOBJ is as follows:
-					// 0x00	- "GOBJ"
-					// 0x04	- Chunk Size (Includes first 16 bytes),
-					// 0x08	- Int; null[2]
 
-					// GOBJ "Header" begins at 0x10 in a GOBJ Chunk.
-					// 0x00	- NJS_OBJECT
-					// NJS_OBJECT should have a child.
-					// Said child node will have a ChunkAttach/NJS_MODEL_CNK, the child pointer is set but it also seems to always follow the first NJS_OBJECT.
-					// As stated above, all pointers are relative to the location of the pointer EXCEPT for the ChunkAttach Pointer for the child.
-					// It has a 1 which does not correspond to the ChunkAttach/NJS_MODEL_CNK's location.
-					// Its location will be immediately after the child NJS_OBJECT.
-					// It's also in a flipped order. The Center/Radius comes first, then the VertexChunk pointer, and the PolyChunk pointer at the end.
 					Type = GroundType.GroundObject;
 					//GOBJChunk = new GOBJ(File, 0);
 					break;

--- a/Libraries/ArchiveLib/SkiesOfArcadia.cs
+++ b/Libraries/ArchiveLib/SkiesOfArcadia.cs
@@ -373,12 +373,23 @@ namespace ArchiveLib
 
 		private string GetNameWithIndex()
 		{
-			return Index.ToString("D3") + "_" + Name;
+			string bitID = "";
+			if (Fxn == "eventhook")
+			{
+				bitID = FunctionParameters[FunctionParameters.Count - 1].ToString();
+		}
+			return Index.ToString("D3") + "_" + Fxn + bitID;
 		}
 
 		private string GetNameAndIndex(int index)
 		{
-			return Index.ToString("D3") + "_" + Name + "_" + index.ToString("D2");
+			string bitID = "";
+			if (Fxn == "eventhook")
+			{
+				bitID = FunctionParameters[FunctionParameters.Count - 1].ToString();
+			}
+			return Index.ToString("D3") + "_" + Fxn + bitID + "_" + index.ToString("D2");
+		}
 		}
 
 		private void GetObjects(byte[] file, int offset)

--- a/Libraries/SAModel/ModelFile.cs
+++ b/Libraries/SAModel/ModelFile.cs
@@ -370,7 +370,7 @@ namespace SAModel
 			}
 		}
 
-		public byte[] ToBytes(string filename, bool nometa = false, bool useNinjaMetaData = false, bool njbLittleEndian = false)
+		public byte[] GetBytes(string filename, bool nometa = false, bool useNinjaMetaData = false, bool njbLittleEndian = false)
 		{
 			uint ninjaMagic;
 			uint imageBase = (uint)(useNinjaMetaData ? 0 : 0x10);

--- a/Libraries/SAModel/ModelFile.cs
+++ b/Libraries/SAModel/ModelFile.cs
@@ -370,7 +370,7 @@ namespace SAModel
 			}
 		}
 
-		public void SaveToFile(string filename, bool nometa = false, bool useNinjaMetaData = false, bool njbLittleEndian = false)
+		public byte[] ToBytes(string filename, bool nometa = false, bool useNinjaMetaData = false, bool njbLittleEndian = false)
 		{
 			uint ninjaMagic;
 			uint imageBase = (uint)(useNinjaMetaData ? 0 : 0x10);
@@ -556,8 +556,16 @@ namespace SAModel
 				file.AddRange(ByteConverter.GetBytes((uint)ChunkTypes.End));
 				file.AddRange(new byte[4]);
 			}
-			File.WriteAllBytes(filename, file.ToArray());
 			ByteConverter.BigEndian = be;
+
+			return file.ToArray();
+		}
+
+		public void SaveToFile(string filename, bool nometa = false, bool useNinjaMetaData = false, bool njbLittleEndian = false)
+		{
+			byte[] file = ToBytes(filename, nometa, useNinjaMetaData, njbLittleEndian);
+			
+			File.WriteAllBytes(filename, file);
 		}
 
 		public static void CreateFile(string filename, NJS_OBJECT model, string[] animationFiles, string author,


### PR DESCRIPTION
I saw that models can now be exported from mld files, but that GRND blocks were not extracted. So I found out that GRND blocks are encoded as a grid-based collision system on compressed meshes. I used the grid to determine and extract the vertices and meshes and put them into a BasicAttach. I also slightly modified ModelFile in SATool: I added a method called ToBytes which performs almost all of the work of SaveToFile but returns the byte array itself. SaveToFile now calls this to get the byte array and then performs the save to file. This way I was able to add the ModelFile bytes for the GRND block to the Entries in the MLDArchive so that it would work with the ArchiveTool.